### PR TITLE
Alias TransientProperties as MemoryProperties

### DIFF
--- a/TransientProperties.gs
+++ b/TransientProperties.gs
@@ -65,4 +65,5 @@ passed as argument to to the TransientProperties constructor.
   }
   
   global.TransientProperties = TransientProperties;
+  global.MemoryProperties = TransientProperties;
 })(this);


### PR DESCRIPTION
Meets the latest OAuth1 having a MemoryProperties object that is essentially the same.  TransientProperties/MemoryProperties's constructor will still accept a properties object.
