### PR TITLE
return ContextText on sendTweet failure

### DIFF
--- a/twitter.gs
+++ b/twitter.gs
@@ -342,7 +342,7 @@ OAuth.prototype.sendTweet = function(tweet, params, options) {
     return JSON.parse(result.getContentText("UTF-8"));
   } catch (e) {
     Logger.log("Send tweet failure. Error was:\n" + JSON.stringify(e) + "\n\noptions were:\n" + JSON.stringify(options) + "\n\n");
-    return null;
+    return JSON.parse(result.getContentText("UTF-8"));
   }
     
 }


### PR DESCRIPTION
A common failure in Apps Script gives "Send tweet failure. Error was: {"name":"Exception"}", which is generated on line 344 but doesn't correctly pass on the error message.

The answer here: https://stackoverflow.com/a/66253113 does what I'm proposing in a sideband test to get the real error message. It can easily be returned instead of null on line 345.